### PR TITLE
Add sudtehexp WordPress theme prototype

### DIFF
--- a/sudtehexp/footer.php
+++ b/sudtehexp/footer.php
@@ -1,0 +1,13 @@
+  </div><!-- .main-content -->
+  <div class="sidebar">
+    <div class="sidebar-inner">
+      <h1>Sudtehexp</h1>
+      <p>Судебно-техническая экспертиза</p>
+      <p>Телеграм: <a href="https://t.me/sudtehexperts">@sudtehexperts</a></p>
+      <p>E-mail: <a href="mailto:sudtehexpert@ya.ru">sudtehexpert@ya.ru</a></p>
+    </div>
+  </div>
+</div><!-- .page -->
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/sudtehexp/functions.php
+++ b/sudtehexp/functions.php
@@ -1,0 +1,55 @@
+<?php
+add_action('after_setup_theme', function(){
+    add_theme_support('post-thumbnails');
+    register_nav_menus(['main_menu' => 'Основное меню']);
+});
+
+add_action('wp_enqueue_scripts', function(){
+    wp_enqueue_style('sudtehexp-fonts', 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;700&display=swap');
+    wp_enqueue_style('sudtehexp-style', get_stylesheet_uri(), [], '1.0');
+});
+
+add_action('init', function(){
+    register_post_type('expertise', [
+        'labels' => [
+            'name' => 'Экспертизы',
+            'singular_name' => 'Экспертиза'
+        ],
+        'public' => true,
+        'supports' => ['title','editor','thumbnail'],
+        'menu_position' => 5
+    ]);
+
+    register_post_type('laboratory', [
+        'labels' => [
+            'name' => 'Лаборатории',
+            'singular_name' => 'Лаборатория'
+        ],
+        'public' => true,
+        'supports' => ['title'],
+        'menu_position' => 6,
+        'register_meta_box_cb' => 'sudtehexp_lab_metaboxes'
+    ]);
+});
+
+function sudtehexp_lab_metaboxes(){
+    add_meta_box('lab_details','Данные лаборатории','sudtehexp_lab_fields','laboratory');
+}
+
+function sudtehexp_lab_fields($post){
+    $inn = get_post_meta($post->ID,'lab_inn',true);
+    $number = get_post_meta($post->ID,'lab_number',true);
+    $term = get_post_meta($post->ID,'lab_term',true);
+    echo '<p><label>ИНН<br><input type="text" name="lab_inn" value="'.esc_attr($inn).'" /></label></p>';
+    echo '<p><label>Номер<br><input type="text" name="lab_number" value="'.esc_attr($number).'" /></label></p>';
+    echo '<p><label>Срок аккредитации<br><input type="text" name="lab_term" value="'.esc_attr($term).'" /></label></p>';
+}
+
+add_action('save_post_laboratory','sudtehexp_save_lab');
+function sudtehexp_save_lab($post_id){
+    if(defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
+    if(isset($_POST['lab_inn'])) update_post_meta($post_id,'lab_inn',sanitize_text_field($_POST['lab_inn']));
+    if(isset($_POST['lab_number'])) update_post_meta($post_id,'lab_number',sanitize_text_field($_POST['lab_number']));
+    if(isset($_POST['lab_term'])) update_post_meta($post_id,'lab_term',sanitize_text_field($_POST['lab_term']));
+}
+?>

--- a/sudtehexp/header.php
+++ b/sudtehexp/header.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+  <meta charset="<?php bloginfo('charset'); ?>">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<div class="page">
+  <div class="main-content">
+<?php wp_nav_menu(array("theme_location"=>"main_menu")); ?>
+

--- a/sudtehexp/index.php
+++ b/sudtehexp/index.php
@@ -1,0 +1,47 @@
+<?php get_header(); ?>
+<div class="hero-video">
+  <button class="showreel-btn">▶ Showreel</button>
+  Для тех, кто защищается —
+</div>
+<section class="services">
+  <?php
+  $query = new WP_Query(array('post_type'=>'expertise','posts_per_page'=>-1));
+  if($query->have_posts()):
+    while($query->have_posts()): $query->the_post(); ?>
+      <div class="card">
+        <?php if(has_post_thumbnail()) { the_post_thumbnail('large'); } ?>
+        <h3><?php the_title(); ?></h3>
+        <?php the_content(); ?>
+      </div>
+  <?php endwhile; wp_reset_postdata(); endif; ?>
+</section>
+<section class="methodology">
+  <h3>Методологический аппарат</h3>
+  <div class="cards">
+    <div class="card">Блок 1</div>
+    <div class="card">Блок 2</div>
+    <div class="card">Блок 3</div>
+  </div>
+</section>
+<section class="clients">
+  <h3>Клиентура</h3>
+  <ul>
+    <li>PetroExpert</li>
+    <li>ExpertizaIndex</li>
+    <li>IrbisCompany</li>
+    <li>EuroExperts</li>
+    <li>Fi.Center</li>
+  </ul>
+</section>
+<section class="contacts-block">
+  <div>
+    <h3>Контакты</h3>
+    <p>Email: <a href="mailto:sudtehexpert@ya.ru">sudtehexpert@ya.ru</a></p>
+    <p>Telegram: <a href="https://t.me/sudtehexperts">@sudtehexperts</a></p>
+  </div>
+  <div class="map">Карта заглушка</div>
+</section>
+<footer>
+  © sudtehexp.ru
+</footer>
+<?php get_footer(); ?>

--- a/sudtehexp/page-laboratorii.php
+++ b/sudtehexp/page-laboratorii.php
@@ -1,0 +1,28 @@
+<?php
+/* Template Name: Лаборатории */
+get_header();
+?>
+<table>
+  <thead>
+    <tr><th>№</th><th>Название</th><th>ИНН</th><th>Срок аккредитации</th></tr>
+  </thead>
+  <tbody>
+  <?php
+  $query = new WP_Query(['post_type'=>'laboratory','posts_per_page'=>-1]);
+  $i=1;
+  if($query->have_posts()):
+    while($query->have_posts()): $query->the_post();
+      $inn = get_post_meta(get_the_ID(),'lab_inn',true);
+      $number = get_post_meta(get_the_ID(),'lab_number',true);
+      $term = get_post_meta(get_the_ID(),'lab_term',true);
+  ?>
+    <tr>
+      <td><?php echo $i++; ?></td>
+      <td><?php the_title(); ?></td>
+      <td><?php echo esc_html($inn); ?></td>
+      <td><?php echo esc_html($term); ?></td>
+    </tr>
+  <?php endwhile; wp_reset_postdata(); endif; ?>
+  </tbody>
+</table>
+<?php get_footer(); ?>

--- a/sudtehexp/page-uslugi.php
+++ b/sudtehexp/page-uslugi.php
@@ -1,0 +1,17 @@
+<?php
+/* Template Name: Услуги */
+get_header();
+?>
+<section class="services">
+<?php
+$query = new WP_Query(['post_type'=>'expertise','posts_per_page'=>-1]);
+if($query->have_posts()):
+  while($query->have_posts()): $query->the_post(); ?>
+    <div class="card">
+      <?php if(has_post_thumbnail()) the_post_thumbnail('large'); ?>
+      <h3><?php the_title(); ?></h3>
+      <?php the_content(); ?>
+    </div>
+<?php endwhile; wp_reset_postdata(); endif; ?>
+</section>
+<?php get_footer(); ?>

--- a/sudtehexp/style.css
+++ b/sudtehexp/style.css
@@ -1,0 +1,211 @@
+/*
+Theme Name: sudtehexp
+Description: Тематика судебных технических экспертиз. Основана на макете beta.ru.
+Author: sudtehexp
+Version: 1.0
+*/
+
+body {
+margin: 0;
+font-family: 'Manrope', sans-serif;
+background: #e1e2e7;
+color: #333;
+}
+.page {
+display: flex;
+}
+.sidebar {
+width: 35%;
+position: fixed;
+right: 0;
+top: 0;
+height: 100vh;
+background: #e1e2e7;
+display: flex;
+justify-content: center;
+align-items: center;
+padding: 40px;
+box-sizing: border-box;
+}
+.sidebar-inner {
+text-align: center;
+max-width: 90%;
+}
+.sidebar-inner h1 {
+font-size: 120px;
+transform: rotate(-10deg);
+margin: 0 0 30px;
+line-height: 1;
+}
+.sidebar-inner p, .sidebar-inner a {
+font-size: 18px;
+margin: 8px 0;
+color: #000;
+text-decoration: none;
+}
+.main-content {
+margin-right: 35%;
+padding: 60px;
+box-sizing: border-box;
+max-width: 1200px;
+}
+.hero-video {
+position: relative;
+background: #ccc;
+height: 450px;
+border-radius: 20px;
+margin-bottom: 60px;
+display: flex;
+align-items: center;
+justify-content: center;
+font-size: 24px;
+color: #333;
+font-weight: bold;
+}
+.showreel-btn {
+position: absolute;
+top: 20px;
+left: 20px;
+background: #fff;
+border: none;
+border-radius: 20px;
+padding: 12px 24px;
+cursor: pointer;
+font-size: 16px;
+}
+.services {
+display: grid;
+grid-template-columns: repeat(2, 1fr);
+gap: 40px;
+margin-bottom: 80px;
+}
+.card {
+background: #fff;
+border-radius: 20px;
+padding: 30px;
+box-shadow: 0 0 20px rgba(0,0,0,0.1);
+}
+.card h3 {
+margin-top: 10px;
+margin-bottom: 10px;
+font-size: 22px;
+}
+.card p {
+font-size: 16px;
+}
+.image-placeholder {
+background: #999;
+height: 200px;
+border-radius: 10px;
+margin-top: 20px;
+display: flex;
+justify-content: center;
+align-items: center;
+color: #fff;
+font-weight: bold;
+}
+.stats {
+display: flex;
+justify-content: space-between;
+margin-bottom: 80px;
+}
+.stat-card {
+flex: 1;
+background: #fff;
+margin: 0 10px;
+border-radius: 20px;
+text-align: center;
+padding: 40px 20px;
+box-shadow: 0 0 20px rgba(0,0,0,0.1);
+}
+.stat-card h2 {
+font-size: 48px;
+margin: 0 0 10px;
+}
+.projects {
+display: grid;
+grid-template-columns: 1fr 1fr;
+gap: 40px;
+margin-bottom: 80px;
+}
+.project-item {
+background: #fff;
+padding: 20px;
+border-radius: 20px;
+box-shadow: 0 0 20px rgba(0,0,0,0.1);
+display: flex;
+justify-content: space-between;
+align-items: center;
+font-size: 16px;
+}
+.project-carousel {
+background: #999;
+height: 300px;
+border-radius: 20px;
+display: flex;
+justify-content: center;
+align-items: center;
+color: #fff;
+font-weight: bold;
+}
+.methodology {
+background: #333;
+color: #fff;
+padding: 40px;
+border-radius: 20px;
+margin-bottom: 80px;
+}
+.methodology h3 {
+margin-bottom: 20px;
+}
+.methodology .cards {
+display: flex;
+gap: 20px;
+}
+.methodology .card {
+background: #555;
+padding: 20px;
+border-radius: 10px;
+flex: 1;
+cursor: pointer;
+text-align: center;
+transition: background 0.3s;
+}
+.methodology .card:hover {
+background: #777;
+}
+.clients, .contacts-block {
+background: #fff;
+padding: 30px;
+border-radius: 20px;
+box-shadow: 0 0 20px rgba(0,0,0,0.1);
+margin-bottom: 60px;
+}
+.clients ul {
+list-style: none;
+columns: 2;
+padding: 0;
+margin: 0;
+}
+.contacts-block {
+display: grid;
+grid-template-columns: 1fr 1fr;
+gap: 40px;
+align-items: start;
+}
+.map {
+background: #999;
+height: 200px;
+border-radius: 10px;
+display: flex;
+justify-content: center;
+align-items: center;
+color: #fff;
+font-weight: bold;
+}
+footer {
+text-align: center;
+font-size: 16px;
+color: #555;
+margin-top: 40px;
+}


### PR DESCRIPTION
## Summary
- add basic WordPress theme `sudtehexp`
- implement custom post types for экспертизы и лаборатории
- include templates for Услуги и Лаборатории pages
- apply styles and layout based on `test.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688981713d9083248cc44eca584c450e